### PR TITLE
added cleanup-on-shutdown; update to 0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 12.0)
 if (DEFINED ENV{FAUCK_VERSION})
 set (VERSION $ENV{FAUCK_VERSION})
 else()
-set (VERSION "0.0.1")
+set (VERSION "0.2.0")
 endif()
 
 project(FaucK VERSION ${VERSION})


### PR DESCRIPTION
propagating the changes for FaucK within `chuck-max` back...

for compatibility, I added this preprocessor check to Faust.cpp, which should compile with both chugin-10.1 and chugin-10.2 API version (the latter will clean up and addresses a potential crash-on-exit):
```
#if( CK_DLL_VERSION_MAJOR >= 10 && CK_DLL_VERSION_MINOR >= 2 )
    // register a callback to be called upon host shutdown (so we can clean up)
    QUERY->register_callback_on_shutdown(QUERY, cb_on_host_shutdown, NULL);
#endif
```
for now, did not change `chugin.h` (it's still 10.1). Everything should be bumped up to chugin API 10.2 by the next chuck release (1.5.2.5).